### PR TITLE
Drop default location remote from app annotations

### DIFF
--- a/packages/app/definition.yaml
+++ b/packages/app/definition.yaml
@@ -33,7 +33,6 @@ metadata:
           path: ".spec.compositionSelector.matchLabels[location]"
           title: Database Location
           description: Select the database location.
-          default: remote
           enum:
           - local
           - remote


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Drops the default location from app annotations because it needs to be
omitted when matching to the frontend composition.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Verified that `location: remote` is currently being set in the UI currently even if nothing is selected.